### PR TITLE
Generate simplest (empty) DOCX document from assets stored in codebase

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,5 @@
 .idea/
 
 /node_modules/
+
+output.docx

--- a/package-lock.json
+++ b/package-lock.json
@@ -6507,9 +6507,9 @@
       }
     },
     "jszip": {
-      "version": "3.2.1",
-      "resolved": "https://registry.npmjs.org/jszip/-/jszip-3.2.1.tgz",
-      "integrity": "sha512-iCMBbo4eE5rb1VCpm5qXOAaUiRKRUKiItn8ah2YQQx9qymmSAY98eyQfioChEYcVQLh0zxJ3wS4A0mh90AVPvw==",
+      "version": "3.2.2",
+      "resolved": "https://registry.npmjs.org/jszip/-/jszip-3.2.2.tgz",
+      "integrity": "sha512-NmKajvAFQpbg3taXQXr/ccS2wcucR1AZ+NtyWp2Nq7HHVsXhcJFR8p0Baf32C2yVvBylFWVeKf+WI2AnvlPhpA==",
       "requires": {
         "lie": "~3.3.0",
         "pako": "~1.0.2",

--- a/package.json
+++ b/package.json
@@ -19,9 +19,10 @@
     "build": "webpack --mode production && electron-builder --windows"
   },
   "dependencies": {
-    "path": "^0.12.7",
     "docx": "^4.7.1",
     "file-system": "^2.2.2",
+    "jszip": "3.2.2",
+    "path": "^0.12.7",
     "react": "16.8.6",
     "react-dom": "16.8.6"
   },

--- a/src/docx/assets/[Content_Types].xml
+++ b/src/docx/assets/[Content_Types].xml
@@ -1,0 +1,15 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Types xmlns="http://schemas.openxmlformats.org/package/2006/content-types">
+  <Default ContentType="application/xml" Extension="xml"/>
+  <Default ContentType="application/vnd.openxmlformats-package.relationships+xml" Extension="rels"/>
+  <Default ContentType="image/png" Extension="png"/>
+  <Default ContentType="image/jpeg" Extension="jpeg"/>
+  <Override ContentType="application/vnd.openxmlformats-package.relationships+xml" PartName="/_rels/.rels"/>
+  <Override ContentType="application/vnd.openxmlformats-officedocument.extended-properties+xml" PartName="/docProps/app.xml"/>
+  <Override ContentType="application/vnd.openxmlformats-package.core-properties+xml" PartName="/docProps/core.xml"/>
+  <Override ContentType="application/vnd.openxmlformats-package.relationships+xml" PartName="/word/_rels/document.xml.rels"/>
+  <Override ContentType="application/vnd.openxmlformats-officedocument.wordprocessingml.fontTable+xml" PartName="/word/fontTable.xml"/>
+  <Override ContentType="application/vnd.openxmlformats-officedocument.wordprocessingml.settings+xml" PartName="/word/settings.xml"/>
+  <Override ContentType="application/vnd.openxmlformats-officedocument.wordprocessingml.document.main+xml" PartName="/word/document.xml"/>
+  <Override ContentType="application/vnd.openxmlformats-officedocument.wordprocessingml.styles+xml" PartName="/word/styles.xml"/>
+</Types>

--- a/src/docx/assets/_rels/.rels
+++ b/src/docx/assets/_rels/.rels
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Relationships xmlns="http://schemas.openxmlformats.org/package/2006/relationships">
+  <Relationship Id="rId1" Target="docProps/core.xml" Type="http://schemas.openxmlformats.org/package/2006/relationships/metadata/core-properties"/>
+  <Relationship Id="rId2" Target="docProps/app.xml" Type="http://schemas.openxmlformats.org/officeDocument/2006/relationships/extended-properties"/>
+  <Relationship Id="rId3" Target="word/document.xml" Type="http://schemas.openxmlformats.org/officeDocument/2006/relationships/officeDocument"/>
+</Relationships>

--- a/src/docx/assets/docProps/app.xml
+++ b/src/docx/assets/docProps/app.xml
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<Properties xmlns="http://schemas.openxmlformats.org/officeDocument/2006/extended-properties" xmlns:vt="http://schemas.openxmlformats.org/officeDocument/2006/docPropsVTypes">
+  <Template/>
+  <TotalTime>0</TotalTime>
+  <Application>LibreOffice/6.2.4.2$Linux_X86_64 LibreOffice_project/20$Build-2</Application>
+  <Pages>1</Pages>
+  <Words>0</Words>
+  <Characters>0</Characters>
+  <CharactersWithSpaces>0</CharactersWithSpaces>
+  <Paragraphs>0</Paragraphs>
+</Properties>

--- a/src/docx/assets/docProps/core.xml
+++ b/src/docx/assets/docProps/core.xml
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<cp:coreProperties xmlns:cp="http://schemas.openxmlformats.org/package/2006/metadata/core-properties" xmlns:dc="http://purl.org/dc/elements/1.1/" xmlns:dcmitype="http://purl.org/dc/dcmitype/" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+  <dcterms:created xsi:type="dcterms:W3CDTF">2019-07-14T15:37:29Z</dcterms:created>
+  <dc:creator/>
+  <dc:description/>
+  <dc:language>en-US</dc:language>
+  <cp:lastModifiedBy/>
+  <cp:revision>0</cp:revision>
+  <dc:subject/>
+  <dc:title/>
+</cp:coreProperties>

--- a/src/docx/assets/word/_rels/document.xml.rels
+++ b/src/docx/assets/word/_rels/document.xml.rels
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Relationships xmlns="http://schemas.openxmlformats.org/package/2006/relationships">
+  <Relationship Id="rId1" Target="styles.xml" Type="http://schemas.openxmlformats.org/officeDocument/2006/relationships/styles"/>
+  <Relationship Id="rId2" Target="fontTable.xml" Type="http://schemas.openxmlformats.org/officeDocument/2006/relationships/fontTable"/>
+  <Relationship Id="rId3" Target="settings.xml" Type="http://schemas.openxmlformats.org/officeDocument/2006/relationships/settings"/>
+</Relationships>

--- a/src/docx/assets/word/document.xml
+++ b/src/docx/assets/word/document.xml
@@ -1,0 +1,22 @@
+<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<w:document mc:Ignorable="w14 wp14" xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006" xmlns:o="urn:schemas-microsoft-com:office:office" xmlns:r="http://schemas.openxmlformats.org/officeDocument/2006/relationships" xmlns:v="urn:schemas-microsoft-com:vml" xmlns:w="http://schemas.openxmlformats.org/wordprocessingml/2006/main" xmlns:w10="urn:schemas-microsoft-com:office:word" xmlns:w14="http://schemas.microsoft.com/office/word/2010/wordml" xmlns:wp="http://schemas.openxmlformats.org/drawingml/2006/wordprocessingDrawing" xmlns:wp14="http://schemas.microsoft.com/office/word/2010/wordprocessingDrawing" xmlns:wpg="http://schemas.microsoft.com/office/word/2010/wordprocessingGroup" xmlns:wps="http://schemas.microsoft.com/office/word/2010/wordprocessingShape">
+  <w:body>
+    <w:p>
+      <w:pPr>
+        <w:pStyle w:val="Normal"/>
+        <w:rPr/>
+      </w:pPr>
+      <w:r>
+        <w:rPr/>
+      </w:r>
+    </w:p>
+    <w:sectPr>
+      <w:type w:val="nextPage"/>
+      <w:pgSz w:h="16838" w:w="11906"/>
+      <w:pgMar w:bottom="1134" w:footer="0" w:gutter="0" w:header="0" w:left="1134" w:right="1134" w:top="1134"/>
+      <w:pgNumType w:fmt="decimal"/>
+      <w:formProt w:val="false"/>
+      <w:textDirection w:val="lrTb"/>
+    </w:sectPr>
+  </w:body>
+</w:document>

--- a/src/docx/assets/word/fontTable.xml
+++ b/src/docx/assets/word/fontTable.xml
@@ -1,0 +1,30 @@
+<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<w:fonts xmlns:r="http://schemas.openxmlformats.org/officeDocument/2006/relationships" xmlns:w="http://schemas.openxmlformats.org/wordprocessingml/2006/main">
+  <w:font w:name="Times New Roman">
+    <w:charset w:val="00"/>
+    <w:family w:val="roman"/>
+    <w:pitch w:val="variable"/>
+  </w:font>
+  <w:font w:name="Symbol">
+    <w:charset w:val="02"/>
+    <w:family w:val="roman"/>
+    <w:pitch w:val="variable"/>
+  </w:font>
+  <w:font w:name="Arial">
+    <w:charset w:val="00"/>
+    <w:family w:val="swiss"/>
+    <w:pitch w:val="variable"/>
+  </w:font>
+  <w:font w:name="Liberation Serif">
+    <w:altName w:val="Times New Roman"/>
+    <w:charset w:val="01"/>
+    <w:family w:val="roman"/>
+    <w:pitch w:val="variable"/>
+  </w:font>
+  <w:font w:name="Liberation Sans">
+    <w:altName w:val="Arial"/>
+    <w:charset w:val="01"/>
+    <w:family w:val="swiss"/>
+    <w:pitch w:val="variable"/>
+  </w:font>
+</w:fonts>

--- a/src/docx/assets/word/settings.xml
+++ b/src/docx/assets/word/settings.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<w:settings xmlns:w="http://schemas.openxmlformats.org/wordprocessingml/2006/main">
+  <w:zoom w:percent="100"/>
+  <w:defaultTabStop w:val="709"/>
+</w:settings>

--- a/src/docx/assets/word/styles.xml
+++ b/src/docx/assets/word/styles.xml
@@ -1,0 +1,92 @@
+<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<w:styles mc:Ignorable="w14" xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006" xmlns:w="http://schemas.openxmlformats.org/wordprocessingml/2006/main" xmlns:w14="http://schemas.microsoft.com/office/word/2010/wordml">
+  <w:docDefaults>
+    <w:rPrDefault>
+      <w:rPr>
+        <w:rFonts w:ascii="Liberation Serif" w:cs="Lohit Devanagari" w:eastAsia="Noto Serif CJK SC" w:hAnsi="Liberation Serif"/>
+        <w:kern w:val="2"/>
+        <w:sz w:val="24"/>
+        <w:szCs w:val="24"/>
+        <w:lang w:bidi="hi-IN" w:eastAsia="zh-CN" w:val="en-US"/>
+      </w:rPr>
+    </w:rPrDefault>
+    <w:pPrDefault>
+      <w:pPr>
+        <w:widowControl/>
+      </w:pPr>
+    </w:pPrDefault>
+  </w:docDefaults>
+  <w:style w:styleId="Normal" w:type="paragraph">
+    <w:name w:val="Normal"/>
+    <w:qFormat/>
+    <w:pPr>
+      <w:widowControl/>
+    </w:pPr>
+    <w:rPr>
+      <w:rFonts w:ascii="Liberation Serif" w:cs="Lohit Devanagari" w:eastAsia="Noto Serif CJK SC" w:hAnsi="Liberation Serif"/>
+      <w:color w:val="auto"/>
+      <w:kern w:val="2"/>
+      <w:sz w:val="24"/>
+      <w:szCs w:val="24"/>
+      <w:lang w:bidi="hi-IN" w:eastAsia="zh-CN" w:val="en-US"/>
+    </w:rPr>
+  </w:style>
+  <w:style w:styleId="Heading" w:type="paragraph">
+    <w:name w:val="Heading"/>
+    <w:basedOn w:val="Normal"/>
+    <w:next w:val="TextBody"/>
+    <w:qFormat/>
+    <w:pPr>
+      <w:keepNext w:val="true"/>
+      <w:spacing w:after="120" w:before="240"/>
+    </w:pPr>
+    <w:rPr>
+      <w:rFonts w:ascii="Liberation Sans" w:cs="Lohit Devanagari" w:eastAsia="Noto Sans CJK SC Regular" w:hAnsi="Liberation Sans"/>
+      <w:sz w:val="28"/>
+      <w:szCs w:val="28"/>
+    </w:rPr>
+  </w:style>
+  <w:style w:styleId="TextBody" w:type="paragraph">
+    <w:name w:val="Body Text"/>
+    <w:basedOn w:val="Normal"/>
+    <w:pPr>
+      <w:spacing w:after="140" w:before="0" w:line="276" w:lineRule="auto"/>
+    </w:pPr>
+    <w:rPr/>
+  </w:style>
+  <w:style w:styleId="List" w:type="paragraph">
+    <w:name w:val="List"/>
+    <w:basedOn w:val="TextBody"/>
+    <w:pPr/>
+    <w:rPr>
+      <w:rFonts w:cs="Lohit Devanagari"/>
+    </w:rPr>
+  </w:style>
+  <w:style w:styleId="Caption" w:type="paragraph">
+    <w:name w:val="Caption"/>
+    <w:basedOn w:val="Normal"/>
+    <w:qFormat/>
+    <w:pPr>
+      <w:suppressLineNumbers/>
+      <w:spacing w:after="120" w:before="120"/>
+    </w:pPr>
+    <w:rPr>
+      <w:rFonts w:cs="Lohit Devanagari"/>
+      <w:i/>
+      <w:iCs/>
+      <w:sz w:val="24"/>
+      <w:szCs w:val="24"/>
+    </w:rPr>
+  </w:style>
+  <w:style w:styleId="Index" w:type="paragraph">
+    <w:name w:val="Index"/>
+    <w:basedOn w:val="Normal"/>
+    <w:qFormat/>
+    <w:pPr>
+      <w:suppressLineNumbers/>
+    </w:pPr>
+    <w:rPr>
+      <w:rFonts w:cs="Lohit Devanagari"/>
+    </w:rPr>
+  </w:style>
+</w:styles>

--- a/src/docx/index.js
+++ b/src/docx/index.js
@@ -1,0 +1,39 @@
+const fs = require("fs");
+const path = require("path");
+
+const JSZip = require("jszip");
+
+const ASSETS_LIST = [
+  "_rels/.rels",
+  "docProps/app.xml",
+  "docProps/core.xml",
+  "word/_rels/document.xml.rels",
+  "word/document.xml",
+  "word/fontTable.xml",
+  "word/settings.xml",
+  "word/styles.xml",
+  "[Content_Types].xml"
+];
+
+function generateDocument() {
+  const zip = new JSZip();
+
+  for (let assetPath of ASSETS_LIST) {
+    zip.file(
+      assetPath,
+      fs.readFileSync(path.posix.resolve(__dirname, "assets", assetPath))
+    );
+  }
+
+  return zip;
+}
+
+module.exports = {
+  generateDocument
+};
+
+if (require.main === module) {
+  generateDocument()
+    .generateNodeStream({ type: "nodebuffer", streamFiles: true })
+    .pipe(fs.createWriteStream("output.docx"));
+}


### PR DESCRIPTION
How to test:
* `npm install`
* `node src/docx/index.js`
* open `output.docx` in Microsoft Word.

Generating documents form template is out of the scope of that pull request (I'm assuming that we can work on that with @Rafalkufel together). Also attaching that part of logic to UI is out of scope (as that can be done separately).