### PR TITLE
Add db to gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,5 +5,6 @@
 /build/
 /dist/
 /node_modules/
+/src/alinka.db
 
 output.docx


### PR DESCRIPTION
even though db was removed (https://github.com/CodeForPoznan/alinka-electron/commit/b6f3acccebc84f106b4baef6725fb1720a4a7414) after rebuild alinka.db creates itself